### PR TITLE
Update DaWGs meeting for DST

### DIFF
--- a/ansible_community_meetings.ics
+++ b/ansible_community_meetings.ics
@@ -34,16 +34,15 @@ LOCATION:#ansible-community or https://matrix.to/#/#community:ansible.com
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Documentation working group
-DTSTART:20231128T160000Z
+DTSTART:20240326T150000Z
 DURATION:PT1H
-DTSTAMP:20231120T144201Z
-UID:documentationworkinggroup-20231128
+DTSTAMP:20240326T145334Z
+UID:documentationworkinggroup-20240326
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Documentation working group\nChair:  Sandra McCann (
  samccann)\nDescription:  \nDiscuss everything related to Ansible Documenta
  tion.\n\nAgenda URL:  https://forum.ansible.com/t/documentation-working-gr
- oup-agenda/153/7\nProject URL:  https://github.com/ansible/community/wiki/
- Docs
+ oup-agenda/153/7\nProject URL:  https://forum.ansible.com/g/Docs
 LOCATION:#ansible-docs or https://matrix.to/#/#docs:ansible.com
 END:VEVENT
 BEGIN:VEVENT

--- a/meetings/docs.yaml
+++ b/meetings/docs.yaml
@@ -7,7 +7,7 @@ description: |
 
   Discuss everything related to Ansible Documentation.
 schedule:
-- time: '1600'
+- time: '1500'
   day: Tuesday
   irc: ansible-docs or https://matrix.to/#/#docs:ansible.com
   frequency: weekly

--- a/meetings/ical/docs.ics
+++ b/meetings/ical/docs.ics
@@ -3,16 +3,15 @@ VERSION:2.0
 PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Documentation working group
-DTSTART:20231121T160000Z
+DTSTART:20240326T150000Z
 DURATION:PT1H
-DTSTAMP:20231120T125340Z
-UID:documentationworkinggroup-20231121
+DTSTAMP:20240326T145334Z
+UID:documentationworkinggroup-20240326
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Documentation working group\nChair:  Sandra McCann (
  samccann)\nDescription:  \nDiscuss everything related to Ansible Documenta
  tion.\n\nAgenda URL:  https://forum.ansible.com/t/documentation-working-gr
- oup-agenda/153/7\nProject URL:  https://github.com/ansible/community/wiki/
- Docs
+ oup-agenda/153/7\nProject URL:  https://forum.ansible.com/g/Docs
 LOCATION:#ansible-docs or https://matrix.to/#/#docs:ansible.com
 END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION
Has a stray update to .ics for the forum link since I didn't run the make all on my prior quick link fix Pr.

Must also change [matrix remindbot reminder](https://github.com/anoadragon453/matrix-reminder-bot):
`!listreminders` - to see the current list.
`!cancelreminder DING DING DING DaWGs (documentation WG) meeting here in 60 minutes DING DING DING` - to remove the old one
`!rr every 1w; on tuesday at 10am; DING DING DING DaWGs (documentation WG) meeting here in 60 minutes DING DING DING` to get a reminder an hour before the meeting time. (based on setting this in DST (East coast US).  If you are setting this in another geo, change 10am to whatever is an hour before the meeting in your timezone.  remindbot translates it into UTC I think.